### PR TITLE
Stl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changes
+
 Version 4.2.0 (2019-12-14)
 
-We closed a total of 54 issues (enhancements and bug fixes) through 20 pull requests, since our last release on 2019-09-01.
+We closed a total of 57 issues (enhancements and bug fixes) through 21 pull requests, since our last release on 2019-09-01.
 
 ## Issues Closed
+  - Updating requirements (#211)
+  - Big tarball (#174)
   - Fetch (#176)
   - metadata for examples  (#125)
   - DOC: math rendering in sphinx, and members included for W (#209)
@@ -40,6 +43,7 @@ We closed a total of 54 issues (enhancements and bug fixes) through 20 pull requ
   - BUG: Updating manifest for additional requirements files (#179)
 
 ## Pull Requests
+  - Updating requirements (#211)
   - Fetch (#176)
   - (docs) automatically generate docstrings for class members (#210)
   - (docs) keep file .nojekyll in docs when syncing between docs/ and docsrc/_build/html/ (#207)
@@ -68,7 +72,6 @@ The following individuals contributed to this release:
   - James Gaboardi
   - Levi John Wolf
   - Siddharths8212376
-  
   
 # Changes
 Version 4.1.1 (2019-09-01)

--- a/libpysal/examples/__init__.py
+++ b/libpysal/examples/__init__.py
@@ -44,4 +44,4 @@ def get_path(file_name):
         pth = example.get_path(file_name, verbose=False)
         if pth:
             return pth
-    print("{} is not a file in any installed datasets.")
+    print("{} is not a file in any installed dataset.".format(file_name))

--- a/libpysal/examples/builtin.py
+++ b/libpysal/examples/builtin.py
@@ -47,13 +47,12 @@ class LocalExample:
         Provide a description of the example
         """
         description = [f for f in self.get_file_list() if "README.md" in f][0]
-        with open(description, 'r') as f:
+        with open(description, 'r', encoding="utf8") as f:
             print(f.read())
-
 
     def get_description(self):
         description = [f for f in self.get_file_list() if "README.md" in f][0]
-        with open(description, 'r') as f:
+        with open(description, 'r', encoding="utf8") as f:
             lines = f.readlines()
         return lines[3].strip()
 

--- a/libpysal/io/iohandlers/csvWrapper.py
+++ b/libpysal/io/iohandlers/csvWrapper.py
@@ -18,7 +18,8 @@ class csvWrapper(tables.DataTable):
         Examples
         --------
         >>> import libpysal
-        >>> file_name = libpysal.examples.get_path('stl_hom.csv')
+        >>> stl = libpysal.examples.load_example('stl')
+        >>> file_name = stl.get_path('stl_hom.csv')
         >>> f = libpysal.io.open(file_name,'r')
         >>> y = f.read()
         >>> f.header

--- a/libpysal/io/iohandlers/tests/test_csvWrapper.py
+++ b/libpysal/io/iohandlers/tests/test_csvWrapper.py
@@ -7,10 +7,12 @@ import os
 from sys import version as V
 
 PY3 = int(V[0]) > 2
-
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_DIR = os.path.abspath(os.path.join(TEST_DIR, os.pardir))
 class test_csvWrapper(unittest.TestCase):
     def setUp(self):
-        self.test_file = test_file = pysal_examples.get_path('stl_hom.csv')
+        stl = pysal_examples.load_example('stl')
+        self.test_file = test_file = stl.get_path('stl_hom.csv')
         self.obj = csvWrapper.csvWrapper(test_file, 'r')
 
     def test_len(self):

--- a/libpysal/io/iohandlers/tests/test_csvWrapper.py
+++ b/libpysal/io/iohandlers/tests/test_csvWrapper.py
@@ -7,8 +7,7 @@ import os
 from sys import version as V
 
 PY3 = int(V[0]) > 2
-TEST_DIR = os.path.dirname(os.path.abspath(__file__))
-PROJECT_DIR = os.path.abspath(os.path.join(TEST_DIR, os.pardir))
+
 class test_csvWrapper(unittest.TestCase):
     def setUp(self):
         stl = pysal_examples.load_example('stl')

--- a/libpysal/weights/tests/test__contW_lists.py
+++ b/libpysal/weights/tests/test__contW_lists.py
@@ -68,10 +68,12 @@ class TestContiguityWeights(unittest.TestCase):
 
     def test_true_rook2(self):
         # load queen gal file created using Open Geoda.
-        geodaW = ps_open(
-            pysal_examples.get_path('stl_hom_rook.gal'), 'r').read()
+
+        stl = pysal_examples.load_example('stl')
+        gal_file = test_file = stl.get_path('stl_hom_rook.gal')
+        geodaW = ps_open(gal_file, 'r').read()
         # build matching W with pysal
-        pysalWb = self.build_W(pysal_examples.get_path(
+        pysalWb = self.build_W(stl.get_path(
             'stl_hom.shp'), ROOK, 'POLY_ID_OG')
         # compare output.
         for key in geodaW.neighbors:


### PR DESCRIPTION
There are two examples with the file named "stl_hom.csv", one which we have in our source examples, and a new example pulled from the remote at CSDS. The former includes the polygons in WKT format, while the latter does not. The tests were failing because the latter was being loaded while the former should be used.

This pr fixes than, and includes a couple of other small changes.